### PR TITLE
Update repositories locations to github

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -7,35 +7,35 @@
                                     Local subdirs same as Git project names in Gerrit.
 -->
 
-    <remote name="origin" fetch="https://git.allseenalliance.org/gerrit/" review="git.allseenalliance.org/gerrit/"/>
+    <remote name="origin" fetch="https://github.com/alljoyn/"/>
 
     <default revision="master" remote="origin" />
 
     <!-- Compliance -->
-    <project path="compliance/tests"                name="compliance/tests"/>
+    <project path="compliance/tests"                name="compliance-tests"/>
 
     <!-- Core -->
-    <project path="core/ajtcl"                      name="core/ajtcl"/>
-    <project path="core/alljoyn"                    name="core/alljoyn"/>
-    <project path="core/alljoyn-js"                 name="core/alljoyn-js"/>
-    <project path="core/test"                       name="core/test"/>
+    <project path="core/ajtcl"                      name="core-ajtcl"/>
+    <project path="core/alljoyn"                    name="core-alljoyn"/>
+    <project path="core/alljoyn-js"                 name="core-alljoyn-js"/>
+    <project path="core/test"                       name="core-test"/>
 
     <!-- Data -->
-    <project path="data/datadriven_api"             name="data/datadriven_api"/>
+    <project path="data/datadriven_api"             name="data-datadriven_api"/>
 
     <!-- Devtools -->
-    <project path="devtools/codegen"                name="devtools/codegen"/>
+    <project path="devtools/codegen"                name="devtools-codegen"/>
 
     <!-- Gateway -->
-    <project path="gateway/gwagent"                 name="gateway/gwagent"/>
+    <project path="gateway/gwagent"                 name="gateway-gwagent"/>
 
     <!-- Lighting -->
-    <project path="lighting/service_framework"      name="lighting/service_framework"/>
+    <project path="lighting/service_framework"      name="lighting-service_framework"/>
 
     <!-- Services -->
-    <project path="services/base"                   name="services/base"/>
-    <project path="services/base_tcl"               name="services/base_tcl"/>
-    <project path="services/notification_viewer"    name="services/notification_viewer"/>
-    <project path="multimedia/audio"                name="multimedia/audio"/>
+    <project path="services/base"                   name="services-base"/>
+    <project path="services/base_tcl"               name="services-base_tcl"/>
+    <project path="services/notification_viewer"    name="services-notification_viewer"/>
+    <project path="multimedia/audio"                name="multimedia-audio"/>
 
 </manifest>


### PR DESCRIPTION
AllSeen Alliance has closed down the old gerrit server, and moved all repositories to github.
But repositories like this one were not updated with the new URLs, so various instructions around the web do not work, even if you can locate the new repo manifest repository.